### PR TITLE
NTR - Fix bundle tab display on product detail page

### DIFF
--- a/src/Resources/views/page/product-detail/tabs.html.twig
+++ b/src/Resources/views/page/product-detail/tabs.html.twig
@@ -5,12 +5,7 @@
     {% if page.product.extension('bundles').elements|length > 0 %}
         <li class="nav-item">
             <a class="nav-link" id="bundle-tab" data-toggle="tab" data-offcanvas-tab="true" href="#bundle-tab-pane" role="tab" aria-controls="bundle-tab-pane" aria-selected="false">
-                {{ 'swag-bundle.detail.tabText'|trans }}
-                <span class="nav-link-icon">
-                    {% sw_include '@Storefront/utilities/icon.html.twig' with {
-                        'name': 'shopping-paper-bag-product'
-                    } %}
-                </span>
+                <span>{{ 'swag-bundle.detail.tabText'|trans }}</span>
             </a>
         </li>
     {% endif %}


### PR DESCRIPTION
The nav-link-icon causes the whole nav-link to fall down 10px or so.
Since the Icon is not really necessary or brings any benefits I removed it.