### PR TITLE
"EntityExtensionInterface" -> "EntityExtension"

### DIFF
--- a/src/Core/Content/Product/ProductExtension.php
+++ b/src/Core/Content/Product/ProductExtension.php
@@ -3,14 +3,14 @@
 namespace Swag\BundleExample\Core\Content\Product;
 
 use Shopware\Core\Content\Product\ProductDefinition;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityExtensionInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityExtension;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Inherited;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToManyAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Swag\BundleExample\Core\Content\Bundle\Aggregate\BundleProduct\BundleProductDefinition;
 use Swag\BundleExample\Core\Content\Bundle\BundleDefinition;
 
-class ProductExtension implements EntityExtensionInterface
+class ProductExtension implements EntityExtension
 {
     public function extendFields(FieldCollection $collection): void
     {


### PR DESCRIPTION
Because changes in 6.3 while plugin activation there comes an error without that change
https://forum.shopware.com/discussion/70601/error-after-update-to-shopware-6-3-0
