### PR TITLE
Fix: $tc container named wrong

### DIFF
--- a/src/Resources/app/administration/src/extension/sw-product/view/sw-product-detail-base/sw-product-detail-base.html.twig
+++ b/src/Resources/app/administration/src/extension/sw-product/view/sw-product-detail-base/sw-product-detail-base.html.twig
@@ -1,12 +1,12 @@
 {% block sw_product_detail_attribute_sets %}
     {% parent() %}
-    <sw-card :title="$t('sw-product.detail.bundleCardLabel')"
+    <sw-card :title="$tc('sw-product.detail.bundleCardLabel')"
              :isLoading="isLoading">
         <sw-inherit-wrapper v-if="!isLoading"
                             v-model="product.extensions.bundles"
                             :inheritedValue="parentProduct.extensions ? parentProduct.extensions.bundles : null"
                             :hasParent="!!parentProduct.id"
-                            :label="$t('sw-product.detail.bundleSelectLabel')"
+                            :label="$tc('sw-product.detail.bundleSelectLabel')"
                             isAssociation
                             @inheritance-remove="saveProduct"
                             @inheritance-restore="saveProduct">
@@ -18,7 +18,7 @@
                     labelProperty="name"
                     :disabled="isInherited"
                     :key="isInherited"
-                    :placeholder="$t('sw-product.detail.bundleSelectPlaceholder')">
+                    :placeholder="$tc('sw-product.detail.bundleSelectPlaceholder')">
                 </sw-entity-many-to-many-select>
             </template>
         </sw-inherit-wrapper>


### PR DESCRIPTION
I'm quite new to Shopware, but to me, it looks like the example code is wrong as the `$t` should be `$tc`, at least to me knowledge.